### PR TITLE
Last N Records

### DIFF
--- a/Last N Records/README.md
+++ b/Last N Records/README.md
@@ -1,0 +1,8 @@
+# Last N Records
+
+You run an e-commerce website and want to record the last N order ids in a log. Implement a data structure to accomplish this, with the following API:
+
+- `record(order_id)`: adds the `order_id` to the log
+- `get_last(i)`: gets the `i`-th last element from the log
+
+`i` is guaranteed to be smaller than or equal to N. You should be as efficient with time and space as possible.

--- a/Last N Records/index.js
+++ b/Last N Records/index.js
@@ -1,0 +1,21 @@
+class Logs {
+    constructor(n) {
+        this._n = n;
+        this._records = [];
+        this._writePointer = 0;
+    }
+
+    record(item) {
+        this._records[this._writePointer] = item;
+        this._writePointer = (this._writePointer + 1) % this._n;
+    }
+
+    getLast(n) {
+        return [].concat(
+            this._records.slice(this._writePointer),
+            this._records.slice(0, this._writePointer)
+        );
+    }
+}
+
+module.exports = Logs;

--- a/Last N Records/index.test.js
+++ b/Last N Records/index.test.js
@@ -1,0 +1,15 @@
+const Logs = require('./');
+
+describe('Last N Records', () => {
+    [
+        [5, [1, 2, 3, 4, 5], [1, 2, 3, 4, 5]],
+        [5, [1, 2, 3, 4, 5, 6, 7, 8], [4, 5, 6, 7, 8]],
+        [5, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], [7, 8, 9, 10, 11]]
+    ].forEach(([N, input, output]) => {
+        it(`should return last ${N} records`, () => {
+            const logs = new Logs(N);
+            input.forEach((i) => logs.record(i));
+            expect(logs.getLast(N)).toEqual(output);
+        });
+    });
+});


### PR DESCRIPTION
#### The problem statement

You run an e-commerce website and want to record the last N order ids in a log. Implement a data structure to accomplish this, with the following API:

- `record(order_id)`: adds the `order_id` to the log
- `get_last(i)`: gets the `i`-th last element from the log

`i` is guaranteed to be smaller than or equal to N. You should be as efficient with time and space as possible.

#### Notes about the solution

Storing the data in array of N size seems pretty obvious. A caveat here is how to store only N elements and nothing extra – it's called [circle buffer](https://en.wikipedia.org/wiki/Circular_buffer).

Writing and reading is `O(1)` since we always know the boundaries and memory consumption is `O(n)`.