### PR TITLE
Locking Tree

### DIFF
--- a/Locking Tree/README.md
+++ b/Locking Tree/README.md
@@ -1,0 +1,11 @@
+# Locking Tree
+
+Implement locking in a binary tree. A binary tree node can be locked or unlocked only if all of its descendants or ancestors are not locked.
+
+Design a binary tree node class with the following methods:
+
+- `is_locked`, which returns whether the node is locked
+- `lock`, which attempts to lock the node. If it cannot be locked, then it should return false. Otherwise, it should lock it and return true.
+- `unlock`, which unlocks the node. If it cannot be unlocked, then it should return false. Otherwise, it should unlock it and return true.
+
+You may augment the node to add parent pointers or any other property you would like. You may assume the class is used in a single-threaded program, so there is no need for actual locks or mutexes. Each method should run in `O(h)`, where `h` is the height of the tree.

--- a/Locking Tree/main.cpp
+++ b/Locking Tree/main.cpp
@@ -1,0 +1,104 @@
+#include <iostream>
+#include <cassert>
+
+using namespace std;
+
+class Node {
+public:
+    Node(int _val, Node * _left, Node * _right) : val(_val), left(_left), right(_right) {
+        if (left != NULL) {
+            left->parent = this;
+        }
+        if (right != NULL) {
+            right->parent = this;
+        }
+    };
+
+    int val;
+    bool isLocked = false;
+
+    Node * left = NULL;
+    Node * right = NULL;
+    Node * parent = NULL;
+
+    bool lock() {
+        return lockHelper(true);
+    }
+
+    bool unlock() {
+        return lockHelper(false);
+    }
+
+private:
+    int countOfLockedChildren = 0;
+
+    bool lockHelper(bool lock) {
+        if (lock && isLocked) {
+            return false;
+        }
+
+        if (countOfLockedChildren > 0) {
+            return false;
+        }
+
+        Node * curr = parent;
+
+        while (curr != NULL) {
+            if (curr->isLocked) {
+                return false;
+            }
+            curr = curr->parent;
+        }
+
+        isLocked = lock;
+
+        curr = parent;
+
+        while (curr != NULL) {
+            curr->countOfLockedChildren += lock ? 1 : -1;
+            curr = curr->parent;
+        }
+
+        return true;
+    }
+};
+
+int main() {
+    Node * root = new Node(
+        0,
+        new Node(
+            1,
+            new Node(2, NULL, NULL),
+            new Node(3, NULL, NULL)
+        ),
+        new Node(
+            4,
+            new Node(5, NULL, NULL),
+            new Node(6, NULL, NULL)
+        )
+    );
+
+    cout << "root->isLocked => false: ";
+    assert(!root->isLocked);
+    cout << "OK" << endl;
+
+    cout << "root->left->lock() => true: ";
+    assert(root->left->lock());
+    cout << "OK" << endl;
+
+    cout << "root->left->left->lock() => false: ";
+    assert(!root->left->left->lock());
+    cout << "OK" << endl;
+
+    cout << "root->left->right->lock() => false: ";
+    assert(!root->left->right->lock());
+    cout << "OK" << endl;
+
+    cout << "root->left->unlock() => true: ";
+    assert(root->left->unlock());
+    cout << "OK" << endl;
+
+    cout << "root->left->left->lock() => true: ";
+    assert(root->left->left->lock());
+    cout << "OK" << endl;
+}


### PR DESCRIPTION
> Implement locking in a binary tree. A binary tree node can be locked or unlocked only if all of its descendants or ancestors are not locked.

This problem could be solved straightforward using DFS, but you need `O(h + m)`, where m is a number of nodes in the subtree. Basically, you have to check all the ancestors (not all the nodes, it's only one path in a tree, so it's `O(h)`, where `h` is a height of the tree) and all the nodes below since any of them could be locked.

Actually, `m` operations could be reduced if we keep track on locked nodes below for each node. In that case, you don't need to check all the nodes below, just look at the precalculated number. Certainly, you have to maintain this number updated as nodes get locked or unlocked.