### PR TITLE
Fill Up the Walls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode
+*.out

--- a/Fill Up Walls/README.md
+++ b/Fill Up Walls/README.md
@@ -1,0 +1,9 @@
+# Fill up the Walls
+
+You are given an array of non-negative integers that represents a two-dimensional elevation map where each element is unit-width wall and the integer is the height. Suppose it will rain and all spots between two walls get filled up.
+
+Compute how many units of water remain trapped on the map in `O(N)` time and `O(1)` space.
+
+For example, given the input `[2, 1, 2]`, we can hold `1` unit of water in the middle.
+
+Given the input `[3, 0, 1, 3, 0, 5]`, we can hold `3` units in the first index, `2` in the second, and `3` in the fourth index (we cannot hold `5` since it would run off to the left), so we can trap `8` units of water.

--- a/Fill Up Walls/main.cpp
+++ b/Fill Up Walls/main.cpp
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+vector<int> read(int n) {
+    vector<int> result(n);
+
+    for (int i = 0; i < n; i++) {
+        cin >> result[i];
+    }
+
+    return result;
+}
+
+int getMaxPos(const vector<int> & heights) {
+    int ans = 0;
+
+    for (int i = 0; i < heights.size(); i++) {
+        if (heights[i] > heights[ans]) {
+            ans = i;
+        }
+    }
+
+    return ans;
+}
+
+int getLeftCapacity(const vector<int> & heights, int maxPos) {
+    int prevMax = heights[0];
+    int result = 0;
+
+    for (int i = 1; i < maxPos; i++) {
+        result += max(0, prevMax - heights[i]);
+        prevMax = max(prevMax, heights[i]);
+    }
+
+    return result;
+}
+
+int getRightCapacity(const vector<int> & heights, int maxPos) {
+    int end = heights.size() - 1;
+    int prevMax = heights[end];
+    int result = 0;
+
+    for (int i = end - 1; i > maxPos; i--) {
+        result += max(0, prevMax - heights[i]);
+        prevMax = max(prevMax, heights[i]);
+    }
+
+    return result;
+}
+
+int getFillingUpCapacity(const vector<int> & heights) {
+    int maxPos = getMaxPos(heights);
+
+    return getLeftCapacity(heights, maxPos) + getRightCapacity(heights, maxPos);
+}
+
+int main() {
+    int n;
+    cin >> n;
+
+    vector<int> heights = read(n);
+
+    cout << getFillingUpCapacity(heights) << endl;
+}


### PR DESCRIPTION
### The problem statement

You are given an array of non-negative integers that represents a two-dimensional elevation map where each element is a unit-width wall and the integer is the height. Suppose it will rain and all spots between two walls get filled up.

Compute how many units of water remain trapped on the map in `O(N)` time and `O(1)` space.

### The solution

Obviously, the water would be trapped between two local maxes, so basically we need to keep track of running max (`prevMax`) and count the capacity of each point as `prevMax - heights[i]`.

It's the right way, there's only one thing: what if the running maxes start to go down at some point? Then the water would always fall down to the level of next maximum value, not the previous one.

This illustration helped me to catch a thing:

![8_fsh1or4qs](https://user-images.githubusercontent.com/3001791/44299134-e0afb200-a2f8-11e8-9d55-2af4e2ca0d8b.jpg)

You need to walk in two directions: before and after the global maxima. When you walk from left to right you always know that the highest point is up there so you wouldn't end up the waterfall situation unexpectedly. The same could be done for the right side, you only need to walk backward.

Each operation takes linear time: find the global maxima and walk down and up the heights.