### PR TITLE
Running Median

### DIFF
--- a/Running Median/README.md
+++ b/Running Median/README.md
@@ -1,0 +1,17 @@
+# Running Median
+
+Compute the running median of a sequence of numbers. That is, given a stream of numbers, print out the median of the list so far on each new element.
+
+Recall that the median of an even-numbered list is the average of the two middle numbers.
+
+For example, given the sequence `[2, 1, 5, 7, 2, 0, 5]`, your algorithm should print out:
+
+```
+2
+1.5
+2
+3.5
+2
+2
+2
+```

--- a/Running Median/main.cpp
+++ b/Running Median/main.cpp
@@ -1,0 +1,62 @@
+#include <iostream>
+#include <deque>
+#include <algorithm>
+#include <cmath>
+
+using namespace std;
+
+bool maxCmp(const float & a, const float & b) {
+    return a < b;
+}
+
+bool minCmp(const float & a, const float & b) {
+    return a > b;
+}
+
+void rebalanceHeaps(deque<float> & left, deque<float> & right) {
+    if (left.size() > right.size()) {
+        right.push_back(left.front());
+        left.pop_front();
+    } else {
+        left.push_back(right.front());
+        right.pop_front();
+    }
+    push_heap(right.begin(), right.end(), minCmp);
+    push_heap(left.begin(), left.end(), maxCmp);
+}
+
+float getRunningMedian(float n, deque<float> & left, deque<float> & right) {
+    if (left.empty() || n < left.front()) {
+        left.push_back(n);
+    } else {
+        right.push_back(n);
+    }
+    push_heap(right.begin(), right.end(), minCmp);
+    push_heap(left.begin(), left.end(), maxCmp);
+
+    // each time one of the buckets start to grow
+    // we need to balance them moving the front to another bucket
+    if (abs((int)(left.size() - right.size())) > 1) {
+        rebalanceHeaps(left, right);
+    }
+
+    if (left.size() == right.size()) {
+        return (left.front() + right.front()) / 2;
+    }
+
+    return (left.size() > right.size()) ? left.front() : right.front();
+}
+
+int main() {
+    float n;
+
+    // left bucket represents max heap (maximum element is at the front)
+    // right bucker represents min heap (min element is at the front)
+    deque<float> leftBucket;
+    deque<float> rightBucket;
+
+    while (true) {
+        cin >> n;
+        cout << getRunningMedian(n, leftBucket, rightBucket) << endl;
+    }
+}


### PR DESCRIPTION
### The problem statement

Compute the running median of a sequence of numbers. That is, given a stream of numbers, print out the median of the list so far on each new element.

### The solution

The brute-force solution would be to add numbers to an array and sort it every time each number comes, that would require more and more time as the array grows.

It's easy to notice that we don't need the array to be actually sorted. What if we split the array into two sides: we need to get max and min values (or one of them if the sides are not equal) from each side because it's basically what the median is about.

![6_sxtyar72a](https://user-images.githubusercontent.com/3001791/44619108-09e8b900-a88a-11e8-851b-454d46eaea0f.jpg)

We can use heaps to keep track of max and min values respectively and rebalance heaps each time one of them starts to overcome another, so we can pick up in `O(1)` time necessary values.

Also push and pop values from a heap is `O(log n)` so it's much cheaper than sorting the whole array each time.