### PR TITLE
Tree Reconstruction

### DIFF
--- a/Tree Reconstruction/README.md
+++ b/Tree Reconstruction/README.md
@@ -1,0 +1,25 @@
+# Tree Reconstruction
+
+Given pre-order and in-order traversals of a binary tree, write a function to reconstruct the tree.
+
+For example, given the following preorder traversal:
+
+```
+[a, b, d, e, c, f, g]
+```
+
+And the following inorder traversal:
+
+```
+[d, b, e, a, f, c, g]
+```
+
+You should return the following tree:
+
+```
+    a
+   / \
+  b   c
+ / \ / \
+d  e f  g
+```

--- a/Tree Reconstruction/main.cpp
+++ b/Tree Reconstruction/main.cpp
@@ -1,0 +1,73 @@
+#include <iostream>
+#include <vector>
+#include <cmath>
+
+using namespace std;
+
+class Node {
+public:
+    Node(char _value) : value(_value) {};
+    char value;
+    Node * left;
+    Node * right;
+};
+
+void read(vector<Node *> & v, int n) {
+    for (int i = 0; i < n; i++) {
+        char tmp;
+        cin >> tmp;
+        v[i] = new Node(tmp);
+    }
+}
+
+vector<Node *> slice(const vector<Node *> v, int start, int end) {
+    return vector<Node *>(v.begin() + start, v.begin() + end);
+}
+
+int findNodePos(const vector<Node *> v, Node * needle) {
+    for (auto it = v.begin(); it != v.end(); ++it) {
+        Node * node = *it;
+
+        if (node->value == needle->value) {
+            return it - v.begin();
+        }
+    }
+    return -1;
+}
+
+Node * reconstruct(vector<Node *> preorder, vector<Node *> inorder) {
+    if (preorder.size() == 0 && inorder.size() == 0) {
+        return NULL;
+    }
+    if (preorder.size() == 1 && inorder.size() == 1) {
+        return *preorder.begin();
+    }
+
+    Node * root = *preorder.begin();
+    int rootPos = findNodePos(inorder, root);
+
+    root->left = reconstruct(
+        slice(preorder, 1, 1 + rootPos),
+        slice(inorder, 0, rootPos)
+    );
+    root->right = reconstruct(
+        slice(preorder, 1 + rootPos, preorder.size()),
+        slice(inorder, 1 + rootPos, inorder.size())
+    );
+
+    return root;
+}
+
+int main() {
+    int n;
+    cin >> n;
+
+    vector<Node *> preorder(n);
+    read(preorder, n);
+
+    vector<Node *> inorder(n);
+    read(inorder, n);
+
+    Node * root;
+    root = reconstruct(preorder, inorder);
+}


### PR DESCRIPTION
## The problem statement

Given preorder and inorder traversals of a binary tree, write a function to reconstruct the tree.

For example, given the following pre-order traversal:

```
[a, b, d, e, c, f, g]
```

And the following inorder traversal:

```
[d, b, e, a, f, c, g]
```

You should return the following tree:

```
    a
   / \
  b   c
 / \ / \
d  e f  g
```

## The solution

First of all, let's call to mind preorder and inorder traverses:

**Preorder**:

- evaluate root
- evaluate left node recursively
- evaluate right node recursively

Note that in this case root node is always in the first place.

**Inorder**:

- evaluate left node recursively
- evaluate root
- evaluate right node recursively

Knowing this patterns we can recursively reduce the size of the problem, reconstructing the left and right sides of the tree using the same function:

![uhura_2018-09-22t14_30_36](https://user-images.githubusercontent.com/3001791/45916798-4d781800-be74-11e8-85f2-c7e6a9e0a312.jpg)
