### PR TITLE
LRU

### DIFF
--- a/LRU/README.md
+++ b/LRU/README.md
@@ -1,0 +1,7 @@
+Implement an LRU (Least Recently Used) cache.
+It should be able to be initialized with a cache size n, and contain the following methods:
+
+- `set(key, value)`: sets key to value. If there are already `n` items in the cache and we are adding a new item, then it should also remove the least recently used item.
+- `get(key)`: gets the value at key. If no such key exists, return null.
+
+Each operation should run in `O(1)` time.

--- a/LRU/main.cpp
+++ b/LRU/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <unordered_map>
-#include <deque>
+#include <list>
 #include <cassert>
 
 using namespace std;
@@ -16,13 +16,20 @@ class LRU {
 public:
     LRU(int n) : capacity(n) {};
 
-    void set(int key, int val) {
+    void set(int key, int value) {
         if (storage.find(key) != storage.end()) {
-            storage[key]->value = val;
+            queue.erase(storage[key]);
+            queue.push_front(*storage[key]);
+            queue.front()->value = value;
         } else {
-            storage[key] = new Node(key, val);
+            Node * node = new Node(key, value);
+            queue.push_front(node);
+            storage[key] = queue.begin();
         }
-        touch(key);
+        if (queue.size() > capacity) {
+            storage.erase(queue.back()->key);
+            queue.pop_back();
+        }
     }
 
     int get(int key) {
@@ -30,26 +37,15 @@ public:
             return -1;
         }
 
-        int val = storage[key]->value;
-        touch(key);
+        queue.erase(storage[key]);
+        queue.push_front(*storage[key]);
 
-        return val;
+        return queue.front()->value;
     }
 private:
     int capacity;
-    deque<Node *> queue;
-    unordered_map<int, Node *> storage;
-
-    void touch(int key) {
-        // move last recent used node to the front
-        queue.push_front(storage[key]);
-
-        // maintain the capacity by removing least recent used element
-        if (storage.size() > capacity) {
-            storage.erase(queue.back()->key);
-            queue.pop_back();
-        }
-    }
+    list<Node *> queue;
+    unordered_map<int, decltype(queue.begin())> storage;
 };
 
 int main() {

--- a/LRU/main.cpp
+++ b/LRU/main.cpp
@@ -1,0 +1,79 @@
+#include <iostream>
+#include <unordered_map>
+#include <deque>
+
+using namespace std;
+
+class Node {
+public:
+    Node(int _key, int _value) : key(_key), value(_value) {};
+    int key;
+    int value;
+};
+
+class LRU {
+public:
+    LRU(int n) : capacity(n) {};
+
+    void set(int key, int val) {
+        if (storage.find(key) != storage.end()) {
+            storage[key]->value = val;
+        } else {
+            storage[key] = new Node(key, val);
+        }
+        touch(key);
+    }
+
+    int get(int key) {
+        if (storage.find(key) == storage.end()) {
+            return -1;
+        }
+
+        int val = storage[key]->value;
+        touch(key);
+
+        return val;
+    }
+private:
+    int capacity;
+    deque<Node *> queue;
+    unordered_map<int, Node *> storage;
+
+    void touch(int key) {
+        // move last recent used node to the front
+        queue.push_front(storage[key]);
+
+        // maintain the capacity by removing least recent used element
+        if (storage.size() > capacity) {
+            storage.erase(queue.back()->key);
+            queue.pop_back();
+        }
+    }
+};
+
+int main() {
+    LRU cache(2);
+
+    cache.set(2, 2);
+
+    // 2, it's what we've just set for key=2
+    cout << cache.get(2) << endl;
+    // -1, there's no such node yet
+    cout << cache.get(1) << endl;
+
+    cache.set(1, 1);
+    cache.set(1, 5);
+
+    // 5, it's last element has been set for key=1
+    cout << cache.get(1) << endl;
+    // 2, nothing's changed for key=2
+    cout << cache.get(2) << endl;
+
+    cache.set(8, 8);
+
+    // -1, key=2 is no longer available because of it was least recent used
+    cout << cache.get(2) << endl;
+    // 8, as expected
+    cout << cache.get(8) << endl;
+
+}

--- a/LRU/main.cpp
+++ b/LRU/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <unordered_map>
 #include <deque>
+#include <cassert>
 
 using namespace std;
 
@@ -56,24 +57,19 @@ int main() {
 
     cache.set(2, 2);
 
-    // 2, it's what we've just set for key=2
-    cout << cache.get(2) << endl;
-    // -1, there's no such node yet
-    cout << cache.get(1) << endl;
+    assert(cache.get(2) == 2);
+    assert(cache.get(1) == -1);
 
     cache.set(1, 1);
     cache.set(1, 5);
 
-    // 5, it's last element has been set for key=1
-    cout << cache.get(1) << endl;
-    // 2, nothing's changed for key=2
-    cout << cache.get(2) << endl;
+    assert(cache.get(1) == 5);
+    assert(cache.get(2) == 2);
 
     cache.set(8, 8);
 
-    // -1, key=2 is no longer available because of it was least recent used
-    cout << cache.get(2) << endl;
-    // 8, as expected
-    cout << cache.get(8) << endl;
+    assert(cache.get(1) == -1);
+    assert(cache.get(2) == 2);
+    assert(cache.get(8) == 8);
 
 }


### PR DESCRIPTION
## The problem statement

Implement an LRU (Least Recently Used) cache.

It should be able to be initialized with a cache size n, and contain the following methods:
 - `set(key, value)`: sets node with a key and value. If there are already `n` items in the cache and we are adding a new item, then it should also remove the least recently used item.
- `get(key)`: gets the value at the key. If no such key exists, return `-1`.

 Each operation should run in `O(1)` time.

## The solution

I've been using LRU a lot but have never implemented it, shame on me :-)

There are two data structures to implement all operations in `O(1)`:

- `list`
- `unordered_map`

First is a doubly linked list which provides fast adding and removing head or tail and the same for removing any node. All you need is a pointer to that node in order to change the prev and next pointers.

So the list is used to make an order of access; each time we call `get` or `set` we have to maintain the order, last recent used nodes go to the front and least recent used removed from the back.

Why do we need a map? We have to store the initial position (iterators) in the list in order to get them fast to erase from the list.